### PR TITLE
Fix overflow issue with subcharacter ranges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-retain_mut = "0.1"
+retain_mut = { version = "0.1.4", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+retain_mut = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -910,8 +910,8 @@ impl Debug for Diff<'_, '_> {
             Diff::Delete(range) => ("Delete", bytes(range)),
             Diff::Insert(range) => ("Insert", bytes(range)),
         };
-        // let text = String::from_utf8_lossy(bytes);
-        write!(formatter, "{}({:?})", name, bytes)
+        let text = String::from_utf8_lossy(bytes);
+        write!(formatter, "{}({:?})", name, text)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,3 +17,22 @@ fn test_unicode() {
     let d = diff(snowman, comet);
     assert_eq!(d, vec![Chunk::Delete(snowman), Chunk::Insert(comet)]);
 }
+
+#[test]
+fn test_unicode2() {
+    let a = "[乀丁abcd一]";
+    let b = "[一abcd丁]";
+    let d = diff(a, b);
+    assert_eq!(
+        d,
+        vec![
+            Chunk::Equal("["),
+            Chunk::Delete("乀丁"),
+            Chunk::Insert("一"),
+            Chunk::Equal("abcd"),
+            Chunk::Delete("一"),
+            Chunk::Insert("丁"),
+            Chunk::Equal("]"),
+        ]
+    );
+}


### PR DESCRIPTION
This fixes #9.

When a `Equal` diff contains only part of a single character, it should not exist at all, so this PR removes them. When an `Equal` diff is removed, `Delete` and `Insert` diffs around with only part of a single character should be removed as well, otherwise there will be duplicate diffs.