### PR TITLE
Replace once_cell crate with standard library's OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ rust-version = "1.36"
 [lib]
 doc-scrape-examples = false
 
-[dev-dependencies]
-once_cell = "1"
-
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,9 @@
 use super::*;
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 macro_rules! range {
     ($text:expr) => {{
-        static CHARS: OnceCell<Vec<char>> = OnceCell::new();
+        static CHARS: OnceLock<Vec<char>> = OnceLock::new();
         let chars = CHARS.get_or_init(|| $text.chars().collect());
         Range::new(chars, ..)
     }};


### PR DESCRIPTION
Available since Rust 1.70.